### PR TITLE
fix changes to choices not having any effect

### DIFF
--- a/src/components/Banner.svelte
+++ b/src/components/Banner.svelte
@@ -51,7 +51,7 @@
     }
   }
 
-  const choicesMerged = Object.assign({}, choicesDefaults, choices)
+  $: choicesMerged = Object.assign({}, choicesDefaults, choices)
 
   $: choicesArr = Object.values(choicesMerged).map((item, index) => {
     return Object.assign(


### PR DESCRIPTION
Changes to the choices prop currently don't have any effect because `choicesMerged` is not declared as a reactive variable.
In our case this was causing issues when we wanted to update labels and descriptions of the choices when the user changes the site language. 

This PR changes `choicesMerged` to a reactive variable to ensure the dialog respects the updated choices.