### PR TITLE
Inherit font family from parent selector

### DIFF
--- a/bundle.css
+++ b/bundle.css
@@ -158,6 +158,7 @@
 }
 
 .cookieConsent__Button {
+  font-family: inherit;
   padding: 15px 40px;
   display: block;
   background: white;


### PR DESCRIPTION
Reasoning: for most websites, the font defined in an upper selector like `body` is the one you also want in `button`.

(in Beyonk's case use Cabin font automatically)